### PR TITLE
VBT-1614: Add Hathi ETAS info to individual record page

### DIFF
--- a/jscripts/etasLinking.js
+++ b/jscripts/etasLinking.js
@@ -120,17 +120,20 @@ function getHathiRecordHTML(url, access) {
       <ul title="Holdings Record Display">
         <li class="bibTag">
           <span class="fieldLabelSpan">Online Access:</span>
-		  <span class="hathi-item-wrapper subfieldData">
-    		<a href="${url}" target="_blank" class="hathi-link">Read online at HathiTrust - ${access}</a>
-	    	<div class="hathi-tooltip-container" id="hathi-tooltip" onClick="toggleTooltip(this);">
-		    	<img src="ui/ucladb/images/icon-help_outline-white.svg" alt="Pop-up icon for more information about HathiTrust" class="hathi-help-icon" aria-label="More information about HathiTrust icon" />
-			    <span class="hathi-tooltip-content" id="tooltip-popup">
-				    <img src="ui/ucladb/images/icon-clear-24px.svg" class="hathi-close-icon" id="tooltip-close" alt="Close pop up icon" />
-				    <span class="hathi-tooltip-text"><strong>UCLA Access</strong>: UCLA login required to read full text</span>
-				    <span class="hathi-tooltip-text"><strong>Public Domain Access</strong>: Full text available without UCLA login.</span>
-				    <a href="https://www.hathitrust.org/" target="_blank" class="hathi-tooltip-text hathi-link">Learn more about HathiTrust Access</a>
-			    </span>
-		    </div
+		  <div class="hathi-row-wrapper">
+		    <img src="ui/ucladb/images/hathi-logo-32px.png" alt="HathiTrust logo" class="hathi-logo" />
+		    <span class="hathi-item-wrapper subfieldData">
+    		  <a href="${url}" target="_blank" class="hathi-link">Read online at HathiTrust - ${access}</a>
+	    	  <div class="hathi-tooltip-container" id="hathi-tooltip" onClick="toggleTooltip(this);">
+		    	  <img src="ui/ucladb/images/icon-help_outline-white.svg" alt="Pop-up icon for more information about HathiTrust" class="hathi-help-icon" aria-label="More information about HathiTrust icon" />
+			      <span class="hathi-tooltip-content" id="tooltip-popup">
+				      <img src="ui/ucladb/images/icon-clear-24px.svg" class="hathi-close-icon" id="tooltip-close" alt="Close pop up icon" />
+				      <span class="hathi-tooltip-text"><strong>UCLA Access</strong>: UCLA login required to read full text</span>
+				      <span class="hathi-tooltip-text"><strong>Public Domain Access</strong>: Full text available without UCLA login.</span>
+				      <a href="https://www.hathitrust.org/" target="_blank" class="hathi-tooltip-text hathi-link">Learn more about HathiTrust Access</a>
+			      </span>
+			  </div
+			</div>
 		  </span>
         </li>
       </ul>

--- a/jscripts/etasLinking.js
+++ b/jscripts/etasLinking.js
@@ -1,42 +1,101 @@
 function linkETAS() {
-  getBibIds();
+  let page_info = getBibIds();
+  if (page_info.bib_ids) {
+    //hathi_data.items.forEach(addHathiInfo);
+	console.log(page_info.bib_ids);
+	// Async functions return Promises
+	getData(page_info.bib_ids)
+	.then(function(data) {
+	  //console.log('RESULT: ' , data);
+	  items = addHathiInfo(data.items);
+	  console.log('ADDED: ', items);
+	  
+	  // Handle results page
+	  if (page_info.etas_type === 'results') {
+	    displayHathiResults(items);
+	  // Handle record page
+	  } else if (page_info.etas_type === 'record') {
+	    displayHathiRecord(items[0]);
+	  }
+	})
+	.catch(function(error) {
+	  console.log('ERROR: ' , error);
+	})
+  }
 }
 
+
 function getBibIds() {
-  let bib_ids = document.getElementsByName('pageIds');
-  if (bib_ids.length >= 1) {
-	// pageIds can occur twice, in header and footer; just take the first one.
-	// Default value has a dangling comma; remove that.
-    let ids = bib_ids[0].value.slice(0, -1);
-	getData(ids);
+  // Check see if page has the info we need to proceed.
+  let bib_ids;
+  let etas_type;
+  let page_info = {};
+  // First: is this the record page?
+  let bib_list = document.getElementById('etas_bibid');
+  if (bib_list) {
+    bib_ids = bib_list.value; 
+	etas_type = 'record';
+  } else {
+    // If not the record page, is it the search results page?
+    bib_list = document.getElementsByName('pageIds');
+	// This will be a NodeList and always exists, even if empty
+	if (bib_list.length >= 1) {
+	  bib_ids = bib_list[0].value.slice(0, -1);
+	  etas_type = 'results'; 
+	}
   }
+
+  // If bib_ids is not defined here, nothing more to do.
+  // Otherwise, call the web service and proceed.
+  page_info.bib_ids = bib_ids;
+  page_info.etas_type = etas_type;
+  return page_info;
 }
 
 async function getData(bib_ids) {
   let url = 'https://webservices.library.ucla.edu/hathi/data/forids/' + bib_ids;
   let response = await fetch(url);
   let data = await response.json();
-  //console.log(JSON.stringify(data.items));
-  data.items.forEach(addHathiInfo);
+  console.log('DATA: ' , data);
+  return data;
 }
 
-function addHathiInfo(item) {
-  // items have: bibId, oclcNumber, itemType, accessLevel, rightsCode, hathiBibKey
-  let bibId = item.bibID;
-  let etasDiv = document.getElementById('etas_' + bibId);
-  let hathiURL = 'https://catalog.hathitrust.org/Record/' + item.hathiBibKey;
-  if (item.accessLevel && etasDiv) {
-    let accessMessage = 'Public Domain Access';
-    if (item.accessLevel === 'deny') {
-	  hathiURL += '?signon=swle:urn:mace:incommon:ucla.edu';
-	  accessMessage = 'UCLA Access';
+function addHathiInfo(items) {
+  // Augments data from web service by adding URL and message to each item
+  items.forEach(function(item) {
+    if (item.accessLevel) {
+      item.hathiURL = 'https://catalog.hathitrust.org/Record/' + item.hathiBibKey;
+      item.accessMessage = 'Public Domain Access';
+      if (item.accessLevel === 'deny') {
+        item.hathiURL += '?signon=swle:urn:mace:incommon:ucla.edu';
+	    item.accessMessage = 'UCLA Access';
+      }
+    }
+  })
+  return items;
+}
+
+function displayHathiResults(items) {
+  // Iterate over items, updating HTML for each one
+  items.forEach(function(item) {
+    let etasDiv = document.getElementById('etas_' + item.bibID);
+	if (etasDiv) {
+	  etasDiv.innerHTML = getHathiResultsHTML(item.hathiURL, item.accessMessage);
+	  etasDiv.style.display = 'flex';
 	}
-    etasDiv.innerHTML = getHathiHTML(hathiURL, accessMessage); 
+  })
+}
+
+function displayHathiRecord(item) {
+  // Update HTML for single item on record page
+  let etasDiv = document.getElementById('etas_record');
+  if (etasDiv) {
+    etasDiv.innerHTML = getHathiRecordHTML(item.hathiURL, item.accessMessage);
 	etasDiv.style.display = 'flex';
   }
 }
 
-function getHathiHTML(url, access) {
+function getHathiResultsHTML(url, access) {
   let hathiHTML = `
 	<img src="ui/ucladb/images/hathi-logo-32px.png" alt="HathiTrust logo" class="hathi-logo" />
 	<div class="hathi-item-wrapper">
@@ -51,6 +110,31 @@ function getHathiHTML(url, access) {
 			</span>
 		</div
 	</div>
+  `
+  return hathiHTML;
+}
+
+function getHathiRecordHTML(url, access) {
+  let hathiHTML = `
+    <div class="evenHoldingsRow">
+      <ul title="Holdings Record Display">
+        <li class="bibTag">
+          <span class="fieldLabelSpan">Online Access:</span>
+		  <span class="hathi-item-wrapper subfieldData">
+    		<a href="${url}" target="_blank" class="hathi-link">Read online at HathiTrust - ${access}</a>
+	    	<div class="hathi-tooltip-container" id="hathi-tooltip" onClick="toggleTooltip(this);">
+		    	<img src="ui/ucladb/images/icon-help_outline-white.svg" alt="Pop-up icon for more information about HathiTrust" class="hathi-help-icon" aria-label="More information about HathiTrust icon" />
+			    <span class="hathi-tooltip-content" id="tooltip-popup">
+				    <img src="ui/ucladb/images/icon-clear-24px.svg" class="hathi-close-icon" id="tooltip-close" alt="Close pop up icon" />
+				    <span class="hathi-tooltip-text"><strong>UCLA Access</strong>: UCLA login required to read full text</span>
+				    <span class="hathi-tooltip-text"><strong>Public Domain Access</strong>: Full text available without UCLA login.</span>
+				    <a href="https://www.hathitrust.org/" target="_blank" class="hathi-tooltip-text hathi-link">Learn more about HathiTrust Access</a>
+			    </span>
+		    </div
+		  </span>
+        </li>
+      </ul>
+    </div>
   `
   return hathiHTML;
 }

--- a/jscripts/etasLinking.js
+++ b/jscripts/etasLinking.js
@@ -91,7 +91,7 @@ function displayHathiRecord(item) {
   let etasDiv = document.getElementById('etas_record');
   if (etasDiv) {
     etasDiv.innerHTML = getHathiRecordHTML(item.hathiURL, item.accessMessage);
-	etasDiv.style.display = 'flex';
+	etasDiv.style.display = 'block';
   }
 }
 

--- a/jscripts/etasLinking.js
+++ b/jscripts/etasLinking.js
@@ -1,14 +1,10 @@
 function linkETAS() {
   let page_info = getBibIds();
   if (page_info.bib_ids) {
-    //hathi_data.items.forEach(addHathiInfo);
-	console.log(page_info.bib_ids);
 	// Async functions return Promises
 	getData(page_info.bib_ids)
 	.then(function(data) {
-	  //console.log('RESULT: ' , data);
 	  items = addHathiInfo(data.items);
-	  console.log('ADDED: ', items);
 	  
 	  // Handle results page
 	  if (page_info.etas_type === 'results') {
@@ -56,7 +52,6 @@ async function getData(bib_ids) {
   let url = 'https://webservices.library.ucla.edu/hathi/data/forids/' + bib_ids;
   let response = await fetch(url);
   let data = await response.json();
-  console.log('DATA: ' , data);
   return data;
 }
 

--- a/jscripts/googleBooksAvail.js
+++ b/jscripts/googleBooksAvail.js
@@ -47,6 +47,8 @@ function listBookEntries(booksInfo)
       var book = booksInfo[i];
       if (book.bib_key)
       {
+		 // 2020-07-01 akohler: Turn on the "Read online" div which contains Google and Hathi (now disabled) links
+		 document.getElementById('fulltext_label').style.display = '';
          document.getElementById('googleBooksRow').style.display = '';  
          document.getElementById('googleBooks').style.display = 'block';  
          var thumbnailDiv = document.createElement("div");

--- a/jscripts/highLight.js
+++ b/jscripts/highLight.js
@@ -191,6 +191,8 @@ function highlightRecordDisplay(searchTerms) {
    }
 
     for (var arrCount = 0; arrCount < myNodes.length; arrCount++ ) {
+		// Final element in myNodes[] is usually null... check it! akohler 2020-06-29
+	  if (myNodes[arrCount]) {
         var htmlChunk = myNodes[arrCount].innerHTML;
 
         /* Loop thru the html by searchterm */
@@ -202,7 +204,8 @@ function highlightRecordDisplay(searchTerms) {
 
         /* reassign the innerHTML to the newly highlighted chunk */
         myNodes[arrCount].innerHTML = htmlChunk;
-    }
+      }
+	}
    return true;
 }
 

--- a/xsl/contentLayout/display/display.xsl
+++ b/xsl/contentLayout/display/display.xsl
@@ -2002,12 +2002,22 @@
 <!-- ###################################################################### -->
 
 <xsl:template name="BMD9000">
-
     <xsl:variable name="holdingsData">
+		<!-- Insert a div before all in-Voyager holdings, for Hathi/Google access -->
+		<div class="displayHoldings" id="etas_record" style="display: none;">
+		  <!-- Hack to store bib id in HTML in an easy to access place -->
+		  <input type="hidden" value="{$bibID}" id="etas_bibid"/>
+		  <div class="evenHoldingsRow">
+		    <ul title="Holdings Record Display">
+			  <li class="bibTag">
+			    <span class="fieldLabelSpan">Online Access:</span><span class="subfieldData">Hathi Access (PLACEHOLDER)</span>
+			  </li>
+			</ul>
+		  </div>
+		</div>
         <xsl:for-each select="$HoldXML/mfhd:mfhdRecord">
 
             <xsl:variable name="mfhdId" select="@mfhdId"/>
-
             <!-- ## variable used for alternating color ## -->
             <xsl:variable name="classPosition">
                 <xsl:choose>

--- a/xsl/displayRecord.xsl
+++ b/xsl/displayRecord.xsl
@@ -43,6 +43,7 @@
 		<link href="{$css-loc}displayCommon.css"      media="all" type="text/css" rel="stylesheet"/>
 		<link href="{$css-loc}highlight.css"          media="all" type="text/css" rel="stylesheet"/>
 		<link href="{$css-loc}displayGoogleBooks.css" media="all" type="text/css" rel="stylesheet"/>
+		<link href="{$css-loc}displayHathi.css" media="all" type="text/css" rel="stylesheet"/>
 	</xsl:variable>
 	
 	<xsl:variable name="myJavascripts">

--- a/xsl/pageFacets/displayFacets.xsl
+++ b/xsl/pageFacets/displayFacets.xsl
@@ -142,9 +142,12 @@
 			 <!-- Add Hathi Trust template -->
 			 <div style="display:none;" id="fulltext_label">
 			   <label>Read online</label>
+				 <!-- 2020-07-01 akohler: Disable call to Hathi sidebar template -->
+				 <!--
     			 <div id="hathiRow">
 	    		   <xsl:call-template name="hathiTrustAvail"/>
 		    	 </div>
+				 -->
                 <!-- ## mdp add the google book template ## -->
                 <div id="googleBooksRow">
                    <xsl:call-template name="googleBooksAvail"/>

--- a/xsl/pageFacets/displayFacets.xsl
+++ b/xsl/pageFacets/displayFacets.xsl
@@ -26,7 +26,8 @@
     xmlns:slim="http://www.loc.gov/MARC21/slim">
 
 <xsl:include href="../local_googleBooksAvail.xsl"/>
-<xsl:include href="../local_hathiTrustAvail.xsl"/>
+<!-- 2020-06-30 akohler: Disable sidebar Hathi info while ETAS is being used -->
+<!-- <xsl:include href="../local_hathiTrustAvail.xsl"/> -->
 
 <!-- ###################################################################### -->
 


### PR DESCRIPTION
This PR:
* Adds an "Online Access" section to the Holdings section of the individual record page, right above Location(s)
* Refactors javascript from VBT-1613, the results page, to be reusable
* Disables the original Hathi info display in the blue sidebar, as this supersedes that
* Fixes an error in the Ex Libris highlighter javascript which sometimes caused subsequent javascript to fail
